### PR TITLE
Adding psutil to install requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,8 @@ setup(
   download_url = 'https://github.com/browserstack/browserstack-local-python/archive/master.zip',
   keywords = ['BrowserStack', 'Local', 'selenium', 'testing'],
   classifiers = [],
+  install_requires=[
+        'psutil',
+  ],
 )
 


### PR DESCRIPTION
psutil is not installed by default in some python versions. Adding it as an install_requires

![browserstack](https://cloud.githubusercontent.com/assets/179895/19092431/70c05d0a-8a3b-11e6-9f92-dbe609792d7f.gif)
