### PR TITLE
MANIFEST.in: add missing 'include' directives

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
-LICENSE.txt
-README.md
-setup.cfg
-setup.py
+include LICENSE.txt
+include README.md
+include setup.cfg
+include setup.py
 recursive-include browserstack *.py
 recursive-include tests *.py
 


### PR DESCRIPTION
Fixes the following build warnings:

```
reading manifest template 'MANIFEST.in'
warning: manifest_maker: MANIFEST.in, line 1: unknown action 'LICENSE.txt'
warning: manifest_maker: MANIFEST.in, line 2: unknown action 'README.md'
warning: manifest_maker: MANIFEST.in, line 3: unknown action 'setup.cfg'
warning: manifest_maker: MANIFEST.in, line 4: unknown action 'setup.py'
```