### PR TITLE
Add support for multi-word args like --force-local. Version bump.

### DIFF
--- a/browserstack/local.py
+++ b/browserstack/local.py
@@ -11,10 +11,15 @@ class Local:
   def __xstr(self, key, value):
     if key is None:
       return ['']
-    if str(value).lower() == "true":
-      return ['-' + key]
+    if len(key) > 1:
+      key = key.replace("_", "-")
+      key = "--" + key
     else:
-      return ['-' + key, value]
+      key = "-" + key
+    if str(value).lower() == "true":
+      return [key]
+    else:
+      return [key, value]
 
   def _generate_cmd(self):
     cmd = [self.binary_path, '-d', 'start', '-logFile', self.local_logfile_path, self.key]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
 setup(
   name = 'browserstack-local',
   packages = ['browserstack'],
-  version = '1.2.2',
+  version = '1.2.4',
   description = 'Python bindings for Browserstack Local',
   author = 'BrowserStack',
   author_email = 'support@browserstack.com',


### PR DESCRIPTION
This PR adds the ability to pass multi-word flags like "--force-local" to the BrowserStackLocal script when creating a `Local()` instance. For example, BrowserStackLocal can now be started in "force local" mode with `Local(force_local="true").start()`.