### PR TITLE
fix: handle false value in boolean arguments

### DIFF
--- a/browserstack/local.py
+++ b/browserstack/local.py
@@ -13,6 +13,8 @@ class Local:
       return ['']
     if str(value).lower() == "true":
       return ['-' + key]
+    elif str(value).lower() == "false":
+      return ['']
     else:
       return ['-' + key, value]
 

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -53,6 +53,11 @@ class TestLocal(unittest.TestCase):
     self.assertIn('-boolArg1', self.local._generate_cmd())
     self.assertIn('-boolArg2', self.local._generate_cmd())
 
+  def test_custom_boolean_argument_false(self):
+    self.local.start(boolArg1=False, boolArg2=False, onlyCommand=True)
+    self.assertNotIn('-boolArg1', self.local._generate_cmd())
+    self.assertNotIn('-boolArg2', self.local._generate_cmd())
+
   def test_custom_keyval(self):
     self.local.start(customKey1="custom value1", customKey2="custom value2", onlyCommand=True)
     self.assertIn('-customKey1', self.local._generate_cmd())


### PR DESCRIPTION
Currently the binding throws an error is a boolean argument's value is passed as false (say `forcelocal` is sent as false a `expected str, bytes or os.PathLike object, not bool` error is thrown). Added an if for this case.