### PR TITLE
Fix `expected str, bytes or os.PathLike object, not int` - e.g, `httpPort`

### DIFF
--- a/browserstack/local.py
+++ b/browserstack/local.py
@@ -24,7 +24,7 @@ class Local:
     elif str(value).lower() == "false":
       return ['']
     else:
-      return ['-' + key, value]
+      return ['-' + key, str(value)]
 
   def get_package_version(self):
     name = "browserstack-local"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
 setup(
   name = 'browserstack-local',
   packages = ['browserstack'],
-  version = '1.2.8',
+  version = '1.2.9',
   description = 'Python bindings for Browserstack Local',
   long_description=open('README.md').read(),
   long_description_content_type='text/markdown',


### PR DESCRIPTION
Currently, the binding throws an error when value is of type `int`. Example, `httpPort` passed as integer,  error comes `expected str, bytes or os.PathLike object, not int`