### PR TITLE
refactor: Use raw string for regex pattern

### DIFF
--- a/browserstack/local_binary.py
+++ b/browserstack/local_binary.py
@@ -156,7 +156,7 @@ class LocalBinary:
   def __verify_binary(self,path):
     try:
       binary_response = subprocess.check_output([path,"--version"]).decode("utf-8")
-      pattern = re.compile("BrowserStack Local version \d+\.\d+")
+      pattern = re.compile(r"BrowserStack Local version \d+\.\d+")
       return bool(pattern.match(binary_response))
     except:
       return False


### PR DESCRIPTION
Without this change there are the following syntax warnings:
```
/usr/lib/python3.13/site-packages/browserstack/local_binary.py:159: SyntaxWarning: invalid escape sequence '\d'
/usr/lib/python3.13/site-packages/browserstack/local_binary.py:159: SyntaxWarning: invalid escape sequence '\d'
```