### PR TITLE
[LOC-5083] Add support for Linux arm64 binary

### DIFF
--- a/browserstack/local_binary.py
+++ b/browserstack/local_binary.py
@@ -24,6 +24,8 @@ class LocalBinary:
     elif osname == 'Linux':
       if self.is_alpine():
         self.http_path = source_url + "BrowserStackLocal-alpine"
+      elif platform.machine() == 'aarch64':
+        self.http_path = source_url + "BrowserStackLocal-linux-arm64"
       else:
         if is_64bits:
           self.http_path = source_url + "BrowserStackLocal-linux-x64"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
 setup(
   name = 'browserstack-local',
   packages = ['browserstack'],
-  version = '1.2.12',
+  version = '1.2.13',
   description = 'Python bindings for Browserstack Local',
   long_description=open('README.md').read(),
   long_description_content_type='text/markdown',


### PR DESCRIPTION
Detect arm64 architecture via platform.machine() == 'aarch64' and download BrowserStackLocal-linux-arm64 binary. This check is placed before the generic is_64bits check to avoid arm64 falling through to the x64 path.